### PR TITLE
Add named transactions

### DIFF
--- a/src/Exception/DuplicateTransactionNameException.php
+++ b/src/Exception/DuplicateTransactionNameException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Lstr\YoPdo\Exception;
+
+use Exception;
+
+class DuplicateTransactionNameException extends Exception
+{
+    /**
+     * @var string
+     */
+    private $transaction_name;
+
+    /**
+     * @param string $transaction_name
+     */
+    public function __construct($transaction_name)
+    {
+        parent::__construct(
+            "Transaction name '{$transaction_name}' is already active."
+        );
+
+        $this->transaction_name = $transaction_name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTransactionName()
+    {
+        return $this->transaction_name;
+    }
+}

--- a/src/Exception/TransactionAcceptanceOrderException.php
+++ b/src/Exception/TransactionAcceptanceOrderException.php
@@ -9,26 +9,26 @@ class TransactionAcceptanceOrderException extends Exception
     /**
      * @var string
      */
-    private $expected_transaction_name;
+    private $expected_name;
 
     /**
      * @var string
      */
-    private $actual_transaction_name;
+    private $actual_name;
 
     /**
-     * @param string $expected_transaction_name
-     * @param string $actual_transaction_name
+     * @param string $expected_name
+     * @param string $actual_name
      */
-    public function __construct($expected_transaction_name, $actual_transaction_name)
+    public function __construct($expected_name, $actual_name)
     {
         parent::__construct(
-            "Transaction name '{$actual_transaction_name}' cannot be accepted before "
-            . "transaction name '{$expected_transaction_name}'."
+            "Transaction name '{$actual_name}' cannot be accepted before "
+            . "transaction name '{$expected_name}'."
         );
 
-        $this->expected_transaction_name = $expected_transaction_name;
-        $this->actual_transaction_name = $actual_transaction_name;
+        $this->expected_name = $expected_name;
+        $this->actual_name = $actual_name;
     }
 
     /**
@@ -36,7 +36,7 @@ class TransactionAcceptanceOrderException extends Exception
      */
     public function getExpectedTransactionName()
     {
-        return $this->expected_transaction_name;
+        return $this->expected_name;
     }
 
     /**
@@ -44,6 +44,6 @@ class TransactionAcceptanceOrderException extends Exception
      */
     public function getActualTransactionName()
     {
-        return $this->actual_transaction_name;
+        return $this->actual_name;
     }
 }

--- a/src/Exception/TransactionAcceptanceOrderException.php
+++ b/src/Exception/TransactionAcceptanceOrderException.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Lstr\YoPdo\Exception;
+
+use Exception;
+
+class TransactionAcceptanceOrderException extends Exception
+{
+    /**
+     * @var string
+     */
+    private $expected_transaction_name;
+
+    /**
+     * @var string
+     */
+    private $actual_transaction_name;
+
+    /**
+     * @param string $expected_transaction_name
+     * @param string $actual_transaction_name
+     */
+    public function __construct($expected_transaction_name, $actual_transaction_name)
+    {
+        parent::__construct(
+            "Transaction name '{$actual_transaction_name}' cannot be accepted before "
+            . "transaction name '{$expected_transaction_name}'."
+        );
+
+        $this->expected_transaction_name = $expected_transaction_name;
+        $this->actual_transaction_name = $actual_transaction_name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpectedTransactionName()
+    {
+        return $this->expected_transaction_name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getActualTransactionName()
+    {
+        return $this->actual_transaction_name;
+    }
+}

--- a/src/Exception/UnknownTransactionNameException.php
+++ b/src/Exception/UnknownTransactionNameException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Lstr\YoPdo\Exception;
+
+use Exception;
+
+class UnknownTransactionNameException extends Exception
+{
+    /**
+     * @var string
+     */
+    private $transaction_name;
+
+    /**
+     * @param string $transaction_name
+     */
+    public function __construct($transaction_name)
+    {
+        parent::__construct(
+            "Transaction name '{$transaction_name}' was not started and therefore cannot be accepted."
+        );
+
+        $this->transaction_name = $transaction_name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTransactionName()
+    {
+        return $this->transaction_name;
+    }
+}

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Lstr\YoPdo;
+
+use Lstr\YoPdo\Exception\DuplicateTransactionNameException;
+use Lstr\YoPdo\Exception\TransactionAcceptanceOrderException;
+use Lstr\YoPdo\Exception\UnknownTransactionNameException;
+
+class Transaction
+{
+    /**
+     * @var YoPdo
+     */
+    private $yo_pdo;
+
+    /**
+     * @var array
+     */
+    private $names = [];
+
+    /**
+     * @var string
+     */
+    private $current_name = null;
+
+    /**
+     * @param YoPdo $yo_pdo
+     */
+    public function __construct(YoPdo $yo_pdo)
+    {
+        $this->yo_pdo = $yo_pdo;
+    }
+
+    /**
+     * @return YoPdo
+     */
+    public function getYoPdo()
+    {
+        return $this->yo_pdo;
+    }
+
+    /**
+     * @param string $name
+     * @throws DuplicateTransactionNameException
+     */
+    public function begin($name)
+    {
+        if (isset($this->names[$name])) {
+            throw new DuplicateTransactionNameException($name);
+        }
+
+        if (null === $this->current_name) {
+            $this->yo_pdo->query('BEGIN');
+        }
+
+        $this->names[$name] = true;
+        $this->current_name = $name;
+    }
+
+    /**
+     * @param string $name
+     * @throws TransactionAcceptanceOrderException
+     * @throws UnknownTransactionNameException
+     */
+    public function accept($name)
+    {
+        if (!isset($this->names[$name])) {
+            throw new UnknownTransactionNameException($name);
+        }
+
+        if ($this->current_name !== $name) {
+            throw new TransactionAcceptanceOrderException($this->current_name, $name);
+        }
+
+        unset($this->names[$name]);
+        end($this->names);
+        $this->current_name = key($this->names);
+
+        if (null === $this->current_name) {
+            $this->yo_pdo->query('COMMIT');
+        }
+    }
+}

--- a/src/YoPdo.php
+++ b/src/YoPdo.php
@@ -14,6 +14,11 @@ class YoPdo
     private $pdo;
 
     /**
+     * @var Transaction
+     */
+    private $transaction;
+
+    /**
      * @param PDO $pdo
      */
     public function __construct(PDO $pdo)
@@ -27,6 +32,20 @@ class YoPdo
     public function getPdo()
     {
         return $this->pdo;
+    }
+
+    /**
+     * @return Transaction
+     */
+    public function transaction()
+    {
+        if ($this->transaction) {
+            return $this->transaction;
+        }
+
+        $this->transaction = new Transaction($this);
+
+        return $this->transaction;
     }
 
     /**

--- a/tests/src/Exception/DuplicateTransactionNameExceptionTest.php
+++ b/tests/src/Exception/DuplicateTransactionNameExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Lstr\YoPdo\Exception;
+
+use PHPUnit_Framework_TestCase;
+
+class DuplicateTransactionNameExceptionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException Lstr\YoPdo\Exception\DuplicateTransactionNameException
+     */
+    public function testExceptionIsThrowable()
+    {
+        throw new DuplicateTransactionNameException('duplicate');
+    }
+
+    public function testTransactionNameIsRetrievable()
+    {
+        $transaction_name = 'duplicate_' . uniqid();
+        $exception = new DuplicateTransactionNameException($transaction_name);
+
+        $this->assertEquals($transaction_name, $exception->getTransactionName());
+    }
+}

--- a/tests/src/Exception/TransactionAcceptanceOrderExceptionTest.php
+++ b/tests/src/Exception/TransactionAcceptanceOrderExceptionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Lstr\YoPdo\Exception;
+
+use PHPUnit_Framework_TestCase;
+
+class TransactionAcceptanceOrderExceptionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException Lstr\YoPdo\Exception\TransactionAcceptanceOrderException
+     */
+    public function testExceptionIsThrowable()
+    {
+        throw new TransactionAcceptanceOrderException('expected', 'actual');
+    }
+
+    public function testExpectedTransactionNameIsRetrievable()
+    {
+        $expected = 'expected_' . uniqid();
+        $actual = 'actual_' . uniqid();
+        $exception = new TransactionAcceptanceOrderException($expected, $actual);
+
+        $this->assertEquals($expected, $exception->getExpectedTransactionName());
+    }
+
+    public function testActualTransactionNameIsRetrievable()
+    {
+        $expected = 'expected_' . uniqid();
+        $actual = 'actual_' . uniqid();
+        $exception = new TransactionAcceptanceOrderException($expected, $actual);
+
+        $this->assertEquals($actual, $exception->getActualTransactionName());
+    }
+}

--- a/tests/src/Exception/UnknownTransactionNameExceptionTest.php
+++ b/tests/src/Exception/UnknownTransactionNameExceptionTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Lstr\YoPdo\Exception;
+
+use PHPUnit_Framework_TestCase;
+
+class UnknownTransactionNameExceptionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException Lstr\YoPdo\Exception\UnknownTransactionNameException
+     */
+    public function testExceptionIsThrowable()
+    {
+        throw new UnknownTransactionNameException('unknown');
+    }
+
+    public function testTransactionNameIsRetrievable()
+    {
+        $transaction_name = 'unknown_' . uniqid();
+        $exception = new UnknownTransactionNameException($transaction_name);
+
+        $this->assertEquals($transaction_name, $exception->getTransactionName());
+    }
+}

--- a/tests/src/TestUtil/SampleTableCreator.php
+++ b/tests/src/TestUtil/SampleTableCreator.php
@@ -40,6 +40,18 @@ SQL;
     }
 
     /**
+     * @return array
+     */
+    public function getSampleRows()
+    {
+        return array(
+            1 => array('a' => 3, 'b' => 6),
+            2 => array('a' => 2, 'b' => 4),
+            3 => array('a' => 1, 'b' => 2),
+        );
+    }
+
+    /**
      * @param YoPdo $yo_pdo
      * @param $table_name
      * @param array $rows

--- a/tests/src/TransactionTest.php
+++ b/tests/src/TransactionTest.php
@@ -31,7 +31,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
      */
     public function testTransactionIsCommittedIfNameIsAccepted(YoPdo $yo_pdo)
     {
-        $rows = $this->getSampleRows();
+        $rows = $this->sample_table_creator->getSampleRows();
         $table_name = $this->sample_table_creator->createTable($yo_pdo);
 
         $yo_pdo->transaction()->begin('outer');
@@ -54,7 +54,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
      */
     public function testTransactionCanBeReused(YoPdo $yo_pdo)
     {
-        $rows = $this->getSampleRows();
+        $rows = $this->sample_table_creator->getSampleRows();
         $table_name = $this->sample_table_creator->createTable($yo_pdo);
 
         $yo_pdo->transaction()->begin('first');
@@ -79,7 +79,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
      */
     public function testTransactionIsNotCommittedIfNameIsNotAccepted(YoPdo $yo_pdo)
     {
-        $rows = $this->getSampleRows();
+        $rows = $this->sample_table_creator->getSampleRows();
         $table_name = $this->sample_table_creator->createTable($yo_pdo);
 
         $yo_pdo->transaction()->begin('outer');
@@ -97,7 +97,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
      */
     public function testTransactionIsCommittedIfAllNamesAreAccepted(YoPdo $yo_pdo)
     {
-        $rows = $this->getSampleRows();
+        $rows = $this->sample_table_creator->getSampleRows();
         $table_name = $this->sample_table_creator->createTable($yo_pdo);
 
         $yo_pdo->transaction()->begin('outer');
@@ -122,7 +122,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
      */
     public function testTransactionIsNotCommittedIfNotAllNamesAreAccepted(YoPdo $yo_pdo)
     {
-        $rows = $this->getSampleRows();
+        $rows = $this->sample_table_creator->getSampleRows();
         $table_name = $this->sample_table_creator->createTable($yo_pdo);
 
         $yo_pdo->transaction()->begin('outer');

--- a/tests/src/TransactionTest.php
+++ b/tests/src/TransactionTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Lstr\YoPdo;
+
+use Lstr\YoPdo\TestUtil\QueryResultAsserter;
+use Lstr\YoPdo\TestUtil\SampleTableCreator;
+use PDOException;
+use PHPUnit_Framework_TestCase;
+
+class TransactionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var QueryResultAsserter
+     */
+    private $result_asserter;
+
+    /**
+     * @var SampleTableCreator
+     */
+    private $sample_table_creator;
+
+    public function setUp()
+    {
+        $this->result_asserter = new QueryResultAsserter($this);
+        $this->sample_table_creator = new SampleTableCreator();
+    }
+
+    /**
+     * @dataProvider dbProvider
+     * @param YoPdo $yo_pdo
+     */
+    public function testTransactionIsCommittedIfNameIsAccepted(YoPdo $yo_pdo)
+    {
+        $rows = $this->getSampleRows();
+        $table_name = $this->sample_table_creator->createTable($yo_pdo);
+
+        $yo_pdo->transaction()->begin('outer');
+        $yo_pdo->insert($table_name, $rows[1]);
+        $yo_pdo->insert($table_name, $rows[2]);
+        $yo_pdo->insert($table_name, $rows[3]);
+        $yo_pdo->transaction()->accept('outer');
+
+        try {
+            // make sure an error occurred so we know the results were committed
+            $yo_pdo->query('SELECT oops');
+        } catch (PDOException $exception) {
+            $this->result_asserter->assertResults($yo_pdo, $table_name, $rows);
+        }
+    }
+
+    /**
+     * @dataProvider dbProvider
+     * @param YoPdo $yo_pdo
+     */
+    public function testTransactionCanBeReused(YoPdo $yo_pdo)
+    {
+        $rows = $this->getSampleRows();
+        $table_name = $this->sample_table_creator->createTable($yo_pdo);
+
+        $yo_pdo->transaction()->begin('first');
+        $yo_pdo->insert($table_name, $rows[1]);
+        $yo_pdo->transaction()->accept('first');
+        $yo_pdo->transaction()->begin('second');
+        $yo_pdo->insert($table_name, $rows[2]);
+        $yo_pdo->insert($table_name, $rows[3]);
+        $yo_pdo->transaction()->accept('second');
+
+        try {
+            // make sure an error occurred so we know the results were committed
+            $yo_pdo->query('SELECT oops');
+        } catch (PDOException $exception) {
+            $this->result_asserter->assertResults($yo_pdo, $table_name, $rows);
+        }
+    }
+
+    /**
+     * @dataProvider dbProvider
+     * @param YoPdo $yo_pdo
+     */
+    public function testTransactionIsNotCommittedIfNameIsNotAccepted(YoPdo $yo_pdo)
+    {
+        $rows = $this->getSampleRows();
+        $table_name = $this->sample_table_creator->createTable($yo_pdo);
+
+        $yo_pdo->transaction()->begin('outer');
+        $yo_pdo->insert($table_name, $rows[1]);
+        $yo_pdo->insert($table_name, $rows[2]);
+        $yo_pdo->insert($table_name, $rows[3]);
+
+        $yo_pdo->query('ROLLBACK');
+        $this->result_asserter->assertResults($yo_pdo, $table_name, []);
+    }
+
+    /**
+     * @dataProvider dbProvider
+     * @param YoPdo $yo_pdo
+     */
+    public function testTransactionIsCommittedIfAllNamesAreAccepted(YoPdo $yo_pdo)
+    {
+        $rows = $this->getSampleRows();
+        $table_name = $this->sample_table_creator->createTable($yo_pdo);
+
+        $yo_pdo->transaction()->begin('outer');
+        $yo_pdo->insert($table_name, $rows[1]);
+        $yo_pdo->transaction()->begin('inner');
+        $yo_pdo->insert($table_name, $rows[2]);
+        $yo_pdo->insert($table_name, $rows[3]);
+        $yo_pdo->transaction()->accept('inner');
+        $yo_pdo->transaction()->accept('outer');
+
+        try {
+            // make sure an error occurred so we know the results were committed
+            $yo_pdo->query('SELECT oops');
+        } catch (PDOException $exception) {
+            $this->result_asserter->assertResults($yo_pdo, $table_name, $rows);
+        }
+    }
+
+    /**
+     * @dataProvider dbProvider
+     * @param YoPdo $yo_pdo
+     */
+    public function testTransactionIsNotCommittedIfNotAllNamesAreAccepted(YoPdo $yo_pdo)
+    {
+        $rows = $this->getSampleRows();
+        $table_name = $this->sample_table_creator->createTable($yo_pdo);
+
+        $yo_pdo->transaction()->begin('outer');
+        $yo_pdo->insert($table_name, $rows[1]);
+        $yo_pdo->transaction()->begin('inner');
+        $yo_pdo->insert($table_name, $rows[2]);
+        $yo_pdo->insert($table_name, $rows[3]);
+        $yo_pdo->transaction()->accept('inner');
+
+        $yo_pdo->query('ROLLBACK');
+        $this->result_asserter->assertResults($yo_pdo, $table_name, []);
+    }
+
+    /**
+     * @dataProvider dbProvider
+     * @param YoPdo $yo_pdo
+     * @expectedException \Lstr\YoPdo\Exception\TransactionAcceptanceOrderException
+     */
+    public function testNamesMustBeAcceptedInOppositeOrderTheyWereStarted(YoPdo $yo_pdo)
+    {
+        $yo_pdo->transaction()->begin('outer');
+        $yo_pdo->transaction()->begin('inner');
+        $yo_pdo->transaction()->accept('outer');
+    }
+
+    /**
+     * @dataProvider dbProvider
+     * @param YoPdo $yo_pdo
+     * @expectedException \Lstr\YoPdo\Exception\DuplicateTransactionNameException
+     */
+    public function testDuplicateActiveNamesAreNotAllowed(YoPdo $yo_pdo)
+    {
+        $yo_pdo->transaction()->begin('outer');
+        $yo_pdo->transaction()->begin('outer');
+    }
+
+    /**
+     * @dataProvider dbProvider
+     * @param YoPdo $yo_pdo
+     * @expectedException \Lstr\YoPdo\Exception\UnknownTransactionNameException
+     */
+    public function testAcceptingUnknownNameIsNotAllowed(YoPdo $yo_pdo)
+    {
+        $yo_pdo->transaction()->accept('outer');
+    }
+
+    /**
+     * @return array
+     */
+    public function dbProvider()
+    {
+        $factory = new Factory();
+        $yo_pdo = $factory->createFromConfig($this->getConfig());
+
+        return array(
+            array($yo_pdo),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    private function getConfig()
+    {
+        $config = require __DIR__ . '/../config/config.php';
+
+        return $config['database'];
+    }
+}

--- a/tests/src/YoPdoTest.php
+++ b/tests/src/YoPdoTest.php
@@ -136,7 +136,7 @@ SQL;
      */
     public function testInsert($yo_pdo)
     {
-        $rows = $this->getSampleRows();
+        $rows = $this->sample_table_creator->getSampleRows();
 
         $table_name = $this->sample_table_creator->createTable($yo_pdo);
         foreach ($rows as $row) {
@@ -205,7 +205,7 @@ SQL;
      */
     public function testDeleteRecord($yo_pdo)
     {
-        $rows = $this->getSampleRows();
+        $rows = $this->sample_table_creator->getSampleRows();
         $table_name = $this->sample_table_creator->createPopulatedTable($yo_pdo, $rows);
 
         $expected = $rows;
@@ -270,24 +270,12 @@ SQL;
      */
     private function assertUpdated(YoPdo $yo_pdo, $run_update)
     {
-        $rows = $this->getSampleRows();
+        $rows = $this->sample_table_creator->getSampleRows();
         $table_name = $this->sample_table_creator->createPopulatedTable($yo_pdo, $rows);
 
         $expected = $rows;
         $expected[2] = $run_update($table_name, 'id = 2');
 
         $this->result_asserter->assertResults($yo_pdo, $table_name, $expected);
-    }
-
-    /**
-     * @return array
-     */
-    private function getSampleRows()
-    {
-        return array(
-            1 => array('a' => 3, 'b' => 6),
-            2 => array('a' => 2, 'b' => 4),
-            3 => array('a' => 1, 'b' => 2),
-        );
     }
 }

--- a/tests/src/YoPdoTest.php
+++ b/tests/src/YoPdoTest.php
@@ -37,6 +37,16 @@ class YoPdoTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider dbProvider
+     */
+    public function testTransactionCanBeRetrieved($yo_pdo)
+    {
+        $this->assertInstanceOf('Lstr\YoPdo\Transaction', $yo_pdo->transaction());
+        $this->assertSame($yo_pdo->transaction(), $yo_pdo->transaction(), 'Reuse transaction object');
+        $this->assertSame($yo_pdo, $yo_pdo->transaction()->getYoPdo());
+    }
+
+    /**
+     * @dataProvider dbProvider
      * @expectedException PDOException
      */
     public function testAnErrorInAQueryThrowsAnException($yo_pdo)


### PR DESCRIPTION
Named transactions allow a single server-side transaction
to be started that will only be committed once all client-side
transaction names have been accepted.

This feature allows multiple layers of an application to start
client-side "transactions" on the same database connection without
committing the transaction until all layers have accepted the
transaction as acceptable.
