### PR TITLE
Shorten 'query_result_asserter' variable name

### DIFF
--- a/tests/src/BulkInserterTest.php
+++ b/tests/src/BulkInserterTest.php
@@ -13,7 +13,7 @@ class BulkInserterTest extends PHPUnit_Framework_TestCase
     /**
      * @var QueryResultAsserter
      */
-    private $query_result_asserter;
+    private $result_asserter;
 
     /**
      * @var SampleTableCreator
@@ -22,7 +22,7 @@ class BulkInserterTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->query_result_asserter = new QueryResultAsserter($this);
+        $this->result_asserter = new QueryResultAsserter($this);
         $this->sample_table_creator = new SampleTableCreator();
     }
 
@@ -40,7 +40,7 @@ class BulkInserterTest extends PHPUnit_Framework_TestCase
             [43, 12],
         ]);
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, array(
+        $this->result_asserter->assertResults($yo_pdo, $table_name, array(
             1 => array('a' => 4, 'b' => 5),
             2 => array('a' => 102,'b' => 32),
             3 => array('a' => 43, 'b' => 12),
@@ -61,7 +61,7 @@ class BulkInserterTest extends PHPUnit_Framework_TestCase
             [43, 12],
         ]);
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, array(
+        $this->result_asserter->assertResults($yo_pdo, $table_name, array(
             1 => array('a' => 4, 'b' => 5),
             2 => array('a' => 102,'b' => 32),
             3 => array('a' => 43, 'b' => 12),
@@ -108,7 +108,7 @@ class BulkInserterTest extends PHPUnit_Framework_TestCase
             [43, 12],
         ]);
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, array());
+        $this->result_asserter->assertResults($yo_pdo, $table_name, array());
     }
 
     /**
@@ -125,7 +125,7 @@ class BulkInserterTest extends PHPUnit_Framework_TestCase
             [43, 12],
         ]);
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, array(
+        $this->result_asserter->assertResults($yo_pdo, $table_name, array(
             1 => array('a' => 4, 'b' => 5),
             2 => array('a' => 102,'b' => 32),
             3 => array('a' => 43, 'b' => 12),
@@ -147,7 +147,7 @@ class BulkInserterTest extends PHPUnit_Framework_TestCase
             [43, 12],
         ]);
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, array(
+        $this->result_asserter->assertResults($yo_pdo, $table_name, array(
             1 => array('a' => 4, 'b' => 5),
             2 => array('a' => 102,'b' => 32),
         ));
@@ -167,11 +167,11 @@ class BulkInserterTest extends PHPUnit_Framework_TestCase
             [102, 32],
         ]);
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, array());
+        $this->result_asserter->assertResults($yo_pdo, $table_name, array());
 
         $bulk_inserter->bufferRecord([43, 12]);
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, array(
+        $this->result_asserter->assertResults($yo_pdo, $table_name, array(
             1 => array('a' => 4, 'b' => 5),
             2 => array('a' => 102,'b' => 32),
             3 => array('a' => 43, 'b' => 12),
@@ -192,7 +192,7 @@ class BulkInserterTest extends PHPUnit_Framework_TestCase
             [102, 32],
         ]);
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, array(
+        $this->result_asserter->assertResults($yo_pdo, $table_name, array(
             1 => array('a' => 4, 'b' => 5),
             2 => array('a' => 102,'b' => 32),
         ));
@@ -202,7 +202,7 @@ class BulkInserterTest extends PHPUnit_Framework_TestCase
             [27, 24],
         ]);
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, array(
+        $this->result_asserter->assertResults($yo_pdo, $table_name, array(
             1 => array('a' => 4, 'b' => 5),
             2 => array('a' => 102,'b' => 32),
             3 => array('a' => 43, 'b' => 12),
@@ -256,7 +256,7 @@ class BulkInserterTest extends PHPUnit_Framework_TestCase
             $expected_records[$i + 1] = $record;
         }
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, $expected_records);
+        $this->result_asserter->assertResults($yo_pdo, $table_name, $expected_records);
     }
 
     /**

--- a/tests/src/YoPdoTest.php
+++ b/tests/src/YoPdoTest.php
@@ -13,7 +13,7 @@ class YoPdoTest extends PHPUnit_Framework_TestCase
     /**
      * @var QueryResultAsserter
      */
-    private $query_result_asserter;
+    private $result_asserter;
 
     /**
      * @var SampleTableCreator
@@ -22,7 +22,7 @@ class YoPdoTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->query_result_asserter = new QueryResultAsserter($this);
+        $this->result_asserter = new QueryResultAsserter($this);
         $this->sample_table_creator = new SampleTableCreator();
     }
 
@@ -114,7 +114,7 @@ SQL;
         );
         $yo_pdo->queryMultiple($sql, $params);
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, array(
+        $this->result_asserter->assertResults($yo_pdo, $table_name, array(
             1 => array('a' => $params['row_1_col_a'], 'b' => $params['row_1_col_b']),
             2 => array('a' => $params['row_2_col_a'],'b' => $params['row_2_col_b']),
             3 => array('a' => $params['last_row_col_a'], 'b' => $params['last_row_col_b']),
@@ -133,7 +133,7 @@ SQL;
             $yo_pdo->insert($table_name, $row);
         }
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, $rows);
+        $this->result_asserter->assertResults($yo_pdo, $table_name, $rows);
     }
 
     /**
@@ -207,7 +207,7 @@ SQL;
             array('id' => 2)
         );
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, $expected);
+        $this->result_asserter->assertResults($yo_pdo, $table_name, $expected);
     }
 
     /**
@@ -224,7 +224,7 @@ SQL;
             [43, 12],
         ]);
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, array(
+        $this->result_asserter->assertResults($yo_pdo, $table_name, array(
             1 => array('a' => 4, 'b' => 5),
             2 => array('a' => 102,'b' => 32),
             3 => array('a' => 43, 'b' => 12),
@@ -266,7 +266,7 @@ SQL;
         $expected = $rows;
         $expected[2] = $run_update($table_name, 'id = 2');
 
-        $this->query_result_asserter->assertResults($yo_pdo, $table_name, $expected);
+        $this->result_asserter->assertResults($yo_pdo, $table_name, $expected);
     }
 
     /**


### PR DESCRIPTION
CodeClimate is complaining the variable name is
too long
