### PR TITLE
Add rollbackAll() to Transaction

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -80,4 +80,16 @@ class Transaction
             $this->yo_pdo->query('COMMIT');
         }
     }
+
+    public function rollbackAll()
+    {
+        if (null === $this->current_name) {
+            return;
+        }
+
+        $this->names = [];
+        $this->current_name = null;
+
+        $this->yo_pdo->query('ROLLBACK');
+    }
 }


### PR DESCRIPTION
If anything fails, we'll need the transaction to rollback.
In order to keep transaction management simple, all names
must be rolled back.
