### PR TITLE
Add ability to pass in SQL expressions to insert()/update()

### DIFF
--- a/src/ExpressionValue.php
+++ b/src/ExpressionValue.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Lstr\YoPdo;
+
+class ExpressionValue
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @param string $value
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getString()
+    {
+        return $this->value;
+    }
+}

--- a/tests/src/ExpressionValueTest.php
+++ b/tests/src/ExpressionValueTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Lstr\YoPdo;
+
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @coversDefaultClass \Lstr\YoPdo\ExpressionValue
+ */
+class ExpressionValueTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::getString
+     */
+    public function testValuePassedToConstructorIsSameReturned()
+    {
+        $value = "some_string_" . uniqid();
+        $expression_value = new ExpressionValue($value);
+
+        $this->assertSame($value, $expression_value->getString());
+    }
+}

--- a/tests/src/TestUtil/QueryResultAsserter.php
+++ b/tests/src/TestUtil/QueryResultAsserter.php
@@ -28,8 +28,13 @@ class QueryResultAsserter
      */
     public function assertResults(YoPdo $yo_pdo, $table_name, array $expected_results)
     {
+        $column_sql = '';
+        if ($expected_results && reset($expected_results)) {
+            $column_sql = ', ' . implode(', ', array_keys(reset($expected_results)));
+        }
+
         $sql = <<<SQL
-SELECT id, a, b
+SELECT id {$column_sql}
 FROM {$table_name}
 ORDER BY id
 SQL;
@@ -44,7 +49,8 @@ SQL;
                 );
             } else {
                 $expected_result = $expected_results[$row['id']];
-                if ($expected_result['a'] !== $row['a'] && $expected_result['b'] !== $row['b']) {
+                $expected_result['id'] = $row['id'];
+                if (array_diff_assoc($expected_result, $row) || array_diff_assoc($row, $expected_result)) {
                     $this->test_case->assertEquals($expected_result, $row);
                 }
                 unset($expected_results[$row['id']]);

--- a/tests/src/TestUtil/SampleTableCreator.php
+++ b/tests/src/TestUtil/SampleTableCreator.php
@@ -3,6 +3,7 @@
 namespace Lstr\YoPdo\TestUtil;
 
 use Lstr\YoPdo\YoPdo;
+use Lstr\YoPdo\ExpressionValue;
 
 class SampleTableCreator
 {
@@ -18,7 +19,8 @@ CREATE SEQUENCE {$table_name}_id_seq;
 CREATE TABLE {$table_name} (
     id INT NOT NULL PRIMARY KEY DEFAULT NEXTVAL('{$table_name}_id_seq'::regclass),
     a INT NOT NULL,
-    b INT NOT NULL
+    b INT NOT NULL,
+    c INT
 );
 SQL;
         $yo_pdo->queryMultiple($sql);
@@ -45,10 +47,28 @@ SQL;
     public function getSampleRows()
     {
         return array(
-            1 => array('a' => 3, 'b' => 6),
-            2 => array('a' => 2, 'b' => 4),
-            3 => array('a' => 1, 'b' => 2),
+            1 => array('a' => 3, 'b' => 6), //, 'c' => new ExpressionValue('3 + 6')),
+            2 => array('a' => 2, 'b' => 4), //, 'c' => new ExpressionValue('2 + 4')),
+            3 => array('a' => 1, 'b' => 2), //, 'c' => new ExpressionValue('1 + 2')),
         );
+    }
+
+    /**
+     * @return array
+     */
+    public function getSampleRowsForUpsert()
+    {
+        $rows = [];
+        $expected = [];
+        foreach ($this->getSampleRows() as $row_num => $row) {
+            $row['c'] = new ExpressionValue("{$row['a']} + {$row['b']}");
+            $rows[$row_num] = $row;
+
+            $row['c'] = $row['a'] + $row['b'];
+            $expected[$row_num] = $row;
+        }
+
+        return [$rows, $expected];
     }
 
     /**

--- a/tests/src/YoPdoTest.php
+++ b/tests/src/YoPdoTest.php
@@ -136,14 +136,14 @@ SQL;
      */
     public function testInsert($yo_pdo)
     {
-        $rows = $this->sample_table_creator->getSampleRows();
+        list($rows, $expected) = $this->sample_table_creator->getSampleRowsForUpsert();
 
         $table_name = $this->sample_table_creator->createTable($yo_pdo);
         foreach ($rows as $row) {
             $yo_pdo->insert($table_name, $row);
         }
 
-        $this->result_asserter->assertResults($yo_pdo, $table_name, $rows);
+        $this->result_asserter->assertResults($yo_pdo, $table_name, $expected);
     }
 
     /**

--- a/tests/src/YoPdoTest.php
+++ b/tests/src/YoPdoTest.php
@@ -168,12 +168,12 @@ SQL;
             function ($table_name, $condition) use ($yo_pdo) {
                 $yo_pdo->update(
                     $table_name,
-                    array('a' => 'some_number', 'b' => 'some_number'),
+                    array('a' => 'some_number', 'b' => 'some_number', 'c' => 'some_expression'),
                     $condition,
-                    array('some_number' => 112)
+                    array('some_number' => 112, 'some_expression' => new ExpressionValue('5 + 2'))
                 );
 
-                return array('a' => 112, 'b' => 112);
+                return array('a' => 112, 'b' => 112, 'c' => 7);
             }
         );
     }
@@ -186,15 +186,17 @@ SQL;
         $this->assertUpdated(
             $yo_pdo,
             function ($table_name, $condition) use ($yo_pdo) {
-                $expected = array('a' => 102, 'b' => 120);
+                $values = array('a' => 102, 'b' => 120, 'c' => new ExpressionValue('5 + 2'));
 
                 $yo_pdo->update(
                     $table_name,
-                    array('a', 'b'),
+                    array('a', 'b', 'c'),
                     $condition,
-                    $expected
+                    $values
                 );
 
+                $expected = $values;
+                $expected['c'] = 7;
                 return $expected;
             }
         );
@@ -270,10 +272,9 @@ SQL;
      */
     private function assertUpdated(YoPdo $yo_pdo, $run_update)
     {
-        $rows = $this->sample_table_creator->getSampleRows();
+        list($rows, $expected) = $this->sample_table_creator->getSampleRowsForUpsert();
         $table_name = $this->sample_table_creator->createPopulatedTable($yo_pdo, $rows);
 
-        $expected = $rows;
         $expected[2] = $run_update($table_name, 'id = 2');
 
         $this->result_asserter->assertResults($yo_pdo, $table_name, $expected);


### PR DESCRIPTION
Being able to pass in `NOW()` and similar SQL expressions is currently
not possible. The limitation is inconvenient and this PR will remove the limitation.
